### PR TITLE
Update patches to match current beta

### DIFF
--- a/kobocat.patch
+++ b/kobocat.patch
@@ -20,47 +20,11 @@ index 4d153b37e..61f6705b2 100644
  sentinels==1.0.0
      # via mongomock
  sentry-sdk==1.5.10
-diff --git a/dependencies/pip/requirements.in b/dependencies/pip/requirements.in
-index 94561b3fd..47f236760 100644
---- a/dependencies/pip/requirements.in
-+++ b/dependencies/pip/requirements.in
-@@ -6,9 +6,6 @@
- -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
- -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
- 
--# spss
--https://bitbucket.org/fomcl/savreaderwriter/downloads/savReaderWriter-3.3.0.zip#egg=savreaderwriter
--
- # ssrf
- -e git+https://github.com/kobotoolbox/ssrf-protect@9b97d3f0fd8f737a38dd7a6b64efeffc03ab3cdd#egg=ssrf_protect
- 
-diff --git a/onadata/apps/viewer/tests/test_export_builder.py b/onadata/apps/viewer/tests/test_export_builder.py
-index 0f82253c2..fd3af0a71 100644
---- a/onadata/apps/viewer/tests/test_export_builder.py
-+++ b/onadata/apps/viewer/tests/test_export_builder.py
-@@ -12,7 +12,6 @@ from django.core.files.temp import NamedTemporaryFile
- from django.utils.six import string_types
- from openpyxl import load_workbook
- from pyxform.builder import create_survey_from_xls
--from savReaderWriter import SavReader
- 
- from onadata.apps.api.mongo_helper import MongoHelper
- from onadata.apps.main.tests.test_base import TestBase
 diff --git a/onadata/settings/base.py b/onadata/settings/base.py
-index 3ea5fcea2..f5d127e75 100644
+index cf2d65df6..9f89ae29d 100644
 --- a/onadata/settings/base.py
 +++ b/onadata/settings/base.py
-@@ -350,7 +350,8 @@ DEBUG = env.bool('DJANGO_DEBUG', True)
- 
- # Database (i.e. PostgreSQL)
- DATABASES = {
--    'default': env.db(default="sqlite:///%s/db.sqlite3" % PROJECT_ROOT)
-+    # NOCOMMIT
-+    'default': env.db('KC_DATABASE_URL', default="sqlite:///%s/db.sqlite3" % PROJECT_ROOT)
- }
- # Replacement for TransactionMiddleware
- DATABASES['default']['ATOMIC_REQUESTS'] = True
-@@ -451,7 +452,7 @@ KOBOFORM_SERVER_PORT = env.str('KOBOFORM_SERVER_PORT', '8000')
+@@ -455,7 +455,7 @@ KOBOFORM_SERVER_PORT = env.str('KOBOFORM_SERVER_PORT', '8000')
  KOBOFORM_SERVER_PROTOCOL = env.str('KOBOFORM_SERVER_PROTOCOL', 'http')
  KOBOFORM_LOGIN_AUTOREDIRECT = True
  KOBOFORM_URL = env.url('KOBOFORM_URL', 'http://kf.kobo.local').geturl()

--- a/kpi.patch
+++ b/kpi.patch
@@ -11,25 +11,11 @@ index 60b3b08ba..8bd9d20e1 100644
      # via -r dependencies/pip/requirements.in
  ptyprocess==0.7.0
      # via pexpect
-diff --git a/kobo/settings/base.py b/kobo/settings/base.py
-index 9f41eeeb7..039b4977b 100644
---- a/kobo/settings/base.py
-+++ b/kobo/settings/base.py
-@@ -322,7 +322,8 @@ SKIP_HEAVY_MIGRATIONS = env.bool('SKIP_HEAVY_MIGRATIONS', False)
- # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
- 
- DATABASES = {
--    'default': env.db(default="sqlite:///%s/db.sqlite3" % BASE_DIR),
-+    # NOCOMMIT
-+    'default': env.db('KPI_DATABASE_URL', default="sqlite:///%s/db.sqlite3" % BASE_DIR),
- }
- if 'KC_DATABASE_URL' in os.environ:
-     DATABASES['kobocat'] = env.db_url('KC_DATABASE_URL')
 diff --git a/package.json b/package.json
-index 8dc0d26e9..6ec7293e0 100644
+index 28153efdb..04927aaf0 100644
 --- a/package.json
 +++ b/package.json
-@@ -103,7 +106,7 @@
+@@ -106,7 +106,7 @@
      "lint": "eslint \"jsapp/js/**/*\" --ext .es6,.js,.jsx,.ts,.tsx",
      "show-icons": "opn jsapp/fonts/k-icons.html",
      "generate-icons": "node ./scripts/generate_icons.js",
@@ -38,4 +24,3 @@ index 8dc0d26e9..6ec7293e0 100644
    },
    "repository": "https://github.com/kobotoolbox/kpi.git",
    "author": "alex.dorey@kobotoolbox.org, esmail.fadae@kobotoolbox.org, john.milner@kobotoolbox.org",
-


### PR DESCRIPTION
I updated the patches to apply to the most recent beta on kobocat and kpi. Mostly just by removing changes that are no longer needed.

To keep up with issues like #1, we could apply these periodically, or find a way to obsolete them all.