### PR TITLE
Add CACHE_URL now needed by kpi and kobocat beta

### DIFF
--- a/envfile
+++ b/envfile
@@ -7,6 +7,7 @@ export SKIP_CELERY=True
 export REDIS_SESSION_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/0
 export KPI_BROKER_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/1
 export KOBOCAT_BROKER_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/10
+export CACHE_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/5
 
 export KOBOFORM_INTERNAL_URL="http://$IP:9000"
 export KOBOFORM_URL="$KOBOFORM_INTERNAL_URL"


### PR DESCRIPTION
see:
- https://github.com/kobotoolbox/kobo-install/pull/193
- https://github.com/kobotoolbox/kpi/pull/3862
- https://github.com/kobotoolbox/kobocat/pull/833
- https://github.com/kobotoolbox/kobo-docker/commit/cdcdbe697cb911e9 ...