### PR TITLE
Make it work with the latest `beta`

### DIFF
--- a/convenience/startkc.sh
+++ b/convenience/startkc.sh
@@ -4,7 +4,7 @@ cd ..
 . envfile
 cd ../kobocat
 if [ "$1" == "--install" ]; then
-    pip-sync dependencies/pip/dev.txt
+    pip-sync dependencies/pip/dev_requirements.txt
 fi
 ./manage.py collectstatic --noinput
 ./manage.py runserver 10.6.6.1:9001

--- a/envfile
+++ b/envfile
@@ -8,12 +8,14 @@ export REDIS_SESSION_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/0
 export KPI_BROKER_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/1
 export KOBOCAT_BROKER_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/10
 export CACHE_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/5
+export SERVICE_ACCOUNT_BACKEND_URL=redis://:insecure-redis-kobo-dev@10.6.6.1:60667/6
 
 export KOBOFORM_INTERNAL_URL="http://$IP:9000"
 export KOBOFORM_URL="$KOBOFORM_INTERNAL_URL"
 
 export KOBOCAT_INTERNAL_URL="http://$IP:9001"
 export KOBOCAT_URL="$KOBOCAT_INTERNAL_URL"
+export SERVICE_ACCOUNT_WHITELISTED_HOSTS="$IP:9001"
 
 export ENKETO_INTERNAL_URL="http://$IP:9002"
 export ENKETO_URL="$ENKETO_INTERNAL_URL"


### PR DESCRIPTION
…where "latest `beta`" means:
```
commit db6a145b45d48972aa71158cdd2860afab889861 (HEAD -> beta, origin/public-beta, origin/beta) Merge: dab6f85e7 988870f6a
Author: David Burke <david.burke@kobotoolbox.org>
Date:   Fri Oct 7 12:20:11 2022 -0400

    Merge pull request #4030 from kobotoolbox/envStore-mobx-refactor-off-beta

    Make `envStore` use Mobx
```
```
commit 7e00a6f658408004bb3614d62d06f71539bd4263 (HEAD -> beta, origin/beta) Merge: 63eb6110c 8af01943b
Author: jnm <john@tmoj.net>
Date:   Fri Oct 7 15:28:56 2022 -0400

    Merge pull request #849 from kobotoolbox/improve-bulk-delete-performance

    Fix timeout when deleting many submissions at a time.
```